### PR TITLE
CORE-5354: Lifecycle Kafka Logs S3 Bucket to Infrequent Access and Glacier

### DIFF
--- a/src/initializers/index.js
+++ b/src/initializers/index.js
@@ -16,6 +16,10 @@ export const getUserId = () => {
     return userId;
 };
 
+export const getListIdFromLocation = () => {
+    return window.location.search.split("?listId=").pop() || window.location.pathname.split("/myjstor/outline/").pop().replace("/", "") || undefined;
+};
+
 export const getOutLineInitialData = () => {
     const outlineInitialDataElement = document.getElementById("outline-initial-data");
     let initialData=null;
@@ -28,4 +32,3 @@ export const getOutLineInitialData = () => {
     }
     return initialData;
 };
-


### PR DESCRIPTION
Resolves [CORE-5354](https://jira.jstor.org/browse/CORE-5354)

###### Description
###### success criteria
# Move the existing kafka-logs s3 bucket objects to Infrequent Access (IA) storage class using script in <Implementation Notes>(#implementation) below
# Add a Lifecycle policy to move old kafka-logs bucket data to Glacier (after 90 days)

###### Background
* Infrequent access S3 Objects cost a minimum of 30 days and 128KB. Smaller files, deleted more rapidly are still charged the minimum.
* The Standard - IA storage class is set at the object level and can exist in the same bucket as Standard, allowing you to use lifecycle policies to automatically transition objects between storage classes without any application changes.
* The only consumers of s3 kafka-logs are a) humans manually, and b) sagoku 
* Infrequent Access (IA) lets you get cheaper storage in exchange for more expensive access. The Standard - IA storage class is set at the object level and can exist in the same bucket as Standard, allowing you to use lifecycle policies to automatically transition objects between storage classes without any application changes. This is great for archives like logs you already processed, but might want to look at later. To get an idea of the cost savings when using Infrequent Access (IA), you can use this <S3 Infrequent Access Calculator>(http://www.gulamshakir.com/apps/s3calc/).
* Glacier is a lower-cost alternative to S3 when data is infrequently accessed, such as for archival purposes.
It’s only useful for data that is rarely accessed. It generally takes 3-5 hours to fulfill a retrieval request.

###### {anchor:implementation}Implementation notes

```bash
aws s3 cp \
  --storage-class STANDARD_IA \
  --region='us-east-1' \
  --recursive \
  s3://kafka-logs/ s3://kafka-logs/
```

###### Notify these people
@ithaka/cypress